### PR TITLE
Migrate from module to library layout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Or directly specifying it in the configuration:
 
 ```toml
 [tool.poetry.dependencies."entrypoint.py"]
-version = "^0.1.2"
+version = "^0.2.0"
 ```
 
 Alternatively, the latest version can be included, installing from source:

--- a/changes/9.internal.md
+++ b/changes/9.internal.md
@@ -1,0 +1,1 @@
+Migrate from module to library layout.

--- a/entrypoint/__init__.py
+++ b/entrypoint/__init__.py
@@ -1,0 +1,35 @@
+"""Decorated functions as entry points.
+
+# Example
+
+```python
+# file.py
+from entrypoint import entrypoint
+
+@entrypoint(__name__)
+def main() -> None:
+    print("Hello, world!")
+```
+
+```python
+>>> import file
+>>> # no output
+```
+
+```console
+$ python file.py
+Hello, world!
+```
+"""
+
+__description__ = "Decorated functions as entry points."
+__url__ = "https://github.com/nekitdev/entrypoint.py"
+
+__title__ = "entrypoint"
+__author__ = "nekitdev"
+__license__ = "MIT"
+__version__ = "0.2.0"
+
+from entrypoint.core import EntryPoint, entrypoint, is_main
+
+__all__ = ("EntryPoint", "entrypoint", "is_main")

--- a/entrypoint/core.py
+++ b/entrypoint/core.py
@@ -1,38 +1,6 @@
-"""Decorated functions as entry points.
-
-# Example
-
-```python
-# file.py
-from entrypoint import entrypoint
-
-@entrypoint(__name__)
-def main() -> None:
-    print("Hello, world!")
-```
-
-```python
->>> import file
->>> # no output
-```
-
-```console
-$ python file.py
-Hello, world!
-```
-"""
-
-__description__ = "Decorated functions as entry points."
-__url__ = "https://github.com/nekitdev/entrypoint.py"
-
-__title__ = "entrypoint"
-__author__ = "nekitdev"
-__license__ = "MIT"
-__version__ = "0.1.3"
-
 from typing import Any, Callable, Type, TypeVar, overload
 
-__all__ = ("MAIN", "EntryPoint", "entrypoint", "is_main")
+__all__ = ("EntryPoint", "entrypoint", "is_main")
 
 R = TypeVar("R")
 
@@ -45,6 +13,7 @@ MAIN = "__main__"
 
 
 def is_main(name: str) -> bool:
+    """Checks if `name` equals `__main__`."""
     return name == MAIN
 
 
@@ -88,6 +57,6 @@ def entrypoint(name: str, entrypoint_type: Type[Any] = EntryPoint) -> Any:
 
     Instead of applying dark magic, this function expects
     callers to pass the `__name__` variable as an argument,
-    and merely checks it against `__main__`.
+    and merely checks it against `__main__` when needed.
     """
     return entrypoint_type(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "entrypoint.py"
-version = "0.1.3"
+version = "0.2.0"
 description = "Decorated functions as entry points."
 authors = ["nekitdev"]
 license = "MIT"
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-include = ["CHANGELOG.md", "py.typed", "tests"]
+include = ["CHANGELOG.md", "tests", "entrypoint/py.typed"]
 
 [tool.poetry.urls]
 Discord = "https://nekit.dev/discord"
@@ -29,7 +29,7 @@ Funding = "https://patreon.com/nekitdev"
 Tracker = "https://github.com/nekitdev/entrypoint.py/issues"
 
 [[tool.poetry.packages]]
-include = "entrypoint.py"
+include = "entrypoint"
 
 [tool.poetry.dependencies]
 python = ">= 3.7"
@@ -108,7 +108,7 @@ warn_unused_ignores = false  # compatibility
 
 [tool.changelog]
 name = "entrypoint.py"
-version = "0.1.3"
+version = "0.2.0"
 url = "https://github.com/nekitdev/entrypoint.py"
 directory = "changes"
 output = "CHANGELOG.md"


### PR DESCRIPTION
Move `entrypoint.py` to `entrypoint/core.py`, migrating to library layout.
This is required because `py.typed` file can not be properly recognized by type checkers if not located inside library's directory.