### PR TITLE
Export `MAIN` constant.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Or directly specifying it in the configuration:
 
 ```toml
 [tool.poetry.dependencies."entrypoint.py"]
-version = "^0.2.0"
+version = "^0.3.0"
 ```
 
 Alternatively, the latest version can be included, installing from source:

--- a/changes/11.change.md
+++ b/changes/11.change.md
@@ -1,0 +1,7 @@
+Export the following constant:
+
+```python
+MAIN = "__main__"
+```
+
+`MAIN` can be used to ensure *entry points* will always get called.

--- a/entrypoint/__init__.py
+++ b/entrypoint/__init__.py
@@ -28,7 +28,7 @@ __url__ = "https://github.com/nekitdev/entrypoint.py"
 __title__ = "entrypoint"
 __author__ = "nekitdev"
 __license__ = "MIT"
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 from entrypoint.core import MAIN, EntryPoint, entrypoint, is_main
 

--- a/entrypoint/__init__.py
+++ b/entrypoint/__init__.py
@@ -30,6 +30,6 @@ __author__ = "nekitdev"
 __license__ = "MIT"
 __version__ = "0.2.0"
 
-from entrypoint.core import EntryPoint, entrypoint, is_main
+from entrypoint.core import MAIN, EntryPoint, entrypoint, is_main
 
-__all__ = ("EntryPoint", "entrypoint", "is_main")
+__all__ = ("MAIN", "EntryPoint", "entrypoint", "is_main")

--- a/entrypoint/core.py
+++ b/entrypoint/core.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Type, TypeVar, overload
 
-__all__ = ("EntryPoint", "entrypoint", "is_main")
+__all__ = ("MAIN", "EntryPoint", "entrypoint", "is_main")
 
 R = TypeVar("R")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "entrypoint.py"
-version = "0.2.0"
+version = "0.3.0"
 description = "Decorated functions as entry points."
 authors = ["nekitdev"]
 license = "MIT"
@@ -108,7 +108,7 @@ warn_unused_ignores = false  # compatibility
 
 [tool.changelog]
 name = "entrypoint.py"
-version = "0.2.0"
+version = "0.3.0"
 url = "https://github.com/nekitdev/entrypoint.py"
 directory = "changes"
 output = "CHANGELOG.md"


### PR DESCRIPTION
Export the following constant:

```python
MAIN = "__main__"
```

Which may be useful in some cases, e.g., `is_main(MAIN)` always evaluates to `True`.